### PR TITLE
Support elementary OS

### DIFF
--- a/src/build_multilib_wine
+++ b/src/build_multilib_wine
@@ -492,6 +492,13 @@ function set_lsb_codename()
 			LSB_CODENAME="stretch";;
 		betsy)
 			LSB_CODENAME="jessie";;
+		# elementary OS (newer first)
+		juno)
+			LSB_CODENAME="bionic";;
+		loki)
+			LSB_CODENAME="xenial";;
+		freya)
+			LSB_CODENAME="trusty";;
 	esac
 }
 


### PR DESCRIPTION
elementary OS is a Ubuntu-based distribution and also overrides the lsb_release codenames, so this commit fixes it.