### PR TITLE
Bugfix Contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-## Debian/Ubuntu™ build script for compiling multilib Wine/Wine Staging (build-multilib-wine)
+# build-multilib-wine ``SABERTOOTH BUILD`` - Updated Fork
 
+``build-multilib-wine`` is a Debian/Ubuntu™ build script for compiling multilib Wine/Wine Staging.
 
 ###  Installing
 
@@ -133,11 +134,3 @@ preserve-environment=true
 Logging is done with a separate logging thread... This was done so a FIFO pipe could be utilised. This proved to be simplier and more reliable, than say using TTY redirection, etc. Commands are simply grouped into blocks, with all output redirected to the input of the FIFO pipe. The actual logging thread reads the data coming out of the FIFO pipe output. This is always dumped to the standard console output stream (**stdout**) and (optionally) is written, uncompressed, to a log file. Log file compression is deferred to completion, of the current script operation, to support more advanced (non-streaming) compression techniques, like **lzma**. Generally using deferred compression will always achieve better compression ratios vs. streaming compression, when more advanced compression techniques are used.
 
 The script was originally intended to use **sudo** to gain **root** privileges, as required. However there are a number of flaws, in the way **sudo** works, that made this very difficult. The most significant problem is that subshells, created with **sudo**, do not inherit any exported functions and variables, from the parent shell. Working around this limitation (alone) would have been (potentially) quite messy. So the final version of the script uses **su** to gain **root** privileges, as required. Unfortunately, this does require that Ubuntu user's have a **root** password set.
-
-###  Issues (bugs)
-
-If you have an issue this script then please use the repository Github issue tracker:
-
-[GitHub: bobwya / build-multilib-wine Issues](https://github.com/bobwya/build-multilib-wine/issues)
-
-Where appropriate, please attach a log file (see above: **Logging** section).

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Download and install the latest release version tarball:
 ```
     export release_tag
     cd ~/Downloads
-    wget 'https://github.com/bobwya/build-multilib-wine/releases/latest' -O 'build-multilib-wine.release.json'
-    release_tag="$(sed -n '\@<a href=\"/bobwya/build-multilib-wine/releases/tag/@{s@^.*<a href=\".*releases/tag/\(.*\)\">.*$@\1@g;p}' 'build-multilib-wine.release.json')"
+    wget 'https://github.com/loopyd/build-multilib-wine/releases/latest' -O 'build-multilib-wine.release.json'
+    release_tag="$(sed -n '\@<a href=\"/loopyd/build-multilib-wine/releases/tag/@{s@^.*<a href=\".*releases/tag/\(.*\)\">.*$@\1@g;p}' 'build-multilib-wine.release.json')"
     [[ -z "${release_tag}" ]] && release_tag="master"
-    wget "https://github.com//bobwya/build-multilib-wine/archive/${release_tag}.tar.gz" -O "build-multilib-wine-${release_tag}.tar.gz" \
+    wget "https://github.com/loopyd/build-multilib-wine/archive/${release_tag}.tar.gz" -O "build-multilib-wine-${release_tag}.tar.gz" \
     && tar xvfa "build-multilib-wine-${release_tag}.tar.gz" \
     && cd "build-multilib-wine-${release_tag}" \
     && sudo make install

--- a/man/build_multilib_wine.1
+++ b/man/build_multilib_wine.1
@@ -1,7 +1,8 @@
 .\" 
 .\" build_multilib_wine is multilib Wine (& Wine Staging) build script
 .\" 
-.\" Copyright (C) 2016-2019 Robert Walker
+.\" SABERTOOTH BUILD Copyright (C) 2020 Heavy H. Pawsers
+.\" Original: Copyright (C) 2016-2019 Robert Walker
 .\" 
 .\" This program is free software; you can redistribute it and/or modify
 .\" it under the terms of the GNU General Public License as published by
@@ -17,7 +18,7 @@
 .\" with this program; if not, write to the Free Software Foundation, Inc.,
 .\" 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 .\" 
-.TH BUILD_MULTILIB_WINE 1 "05 Jun 2019"
+.TH BUILD_MULTILIB_WINE 1 "20 May 2020"
 .SH NAME
 \fBbuild_multilib_wine\fR \- monolithic BASH script to build multilib Wine, from source, on Debian or Ubuntu™
 .SH SYNOPSIS

--- a/man/build_multilib_wine.conf.5
+++ b/man/build_multilib_wine.conf.5
@@ -1,7 +1,8 @@
 .\" 
 .\" build_multilib_wine.conf is the configuration file for the build_multilib_wine build script
 .\" 
-.\" Copyright (C) 2016-2019 Robert Walker
+.\" SABERTOOTH BUILD Copyright (C) 2020 Heavy H. Pawsers
+.\" Original: Copyright (C) 2016-2019 Robert Walker
 .\" 
 .\" This program is free software; you can redistribute it and/or modify
 .\" it under the terms of the GNU General Public License as published by
@@ -17,7 +18,7 @@
 .\" with this program; if not, write to the Free Software Foundation, Inc.,
 .\" 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 .\" 
-.TH "BUILD_MULTILIB_WINE.CONF" "5" "05 Jun 2019"
+.TH "BUILD_MULTILIB_WINE.CONF" "5" "20 May 2020"
 .SH "NAME"
 build_multilib_wine.conf \- custom settings for controlling the build_multilib_wine
 script

--- a/src/build_multilib_wine
+++ b/src/build_multilib_wine
@@ -800,9 +800,9 @@ function display_completion_message()
 #
 function fetch_and_extract_tarball()
 {
-	(( ($# == 2) || ($# == 3) )) || die "Invalid parameter count: ${#} (2-3)"
+	(( ($# == 2) || ($# == 3) || ($# == 5) )) || die "Invalid parameter count: ${#} (2-3)"
 	local __directory="${1:-.}" __download_uri="${2}" __tarball
-	if (($# == 3)); then
+	if (($# >= 3)); then
 		__tarball="${3}"
 	else
 		__tarball="$(basename "${__download_uri}")"
@@ -811,6 +811,9 @@ function fetch_and_extract_tarball()
 	wget -O "${__tarball}" "${__download_uri}" || die "wget \"${__download_uri}\" failed"
 	tar xvfa "${__tarball}" || die "tar e(x)tract failed"
 	rm "${__tarball}" || die "rm failed"
+    if (($# == 5)); then
+        rsync -a $4/* ${__directory}/$5 || die "copy into parent failed"
+    fi
 	[[ "${__directory}" != "." ]] && popd_wrapper
 }
 
@@ -860,7 +863,7 @@ clean_source_directories()
 	done
 }
 
-# function fetch_and_extract_tarball()
+# function clean_build_directories()
 #
 # Parameters:
 #     1[-N]>  directories_array : build directories to wipe  (string array)
@@ -2140,7 +2143,7 @@ function src_fetch()
 
 	clean_build_directories "${BUILD_ROOT}/wine64" "${BUILD_ROOT}/wine32" "${BUILD_ROOT}/wine32_tools"
 	pushd_wrapper "${SOURCE_ROOT}"
-	fetch_and_extract_tarball . "${GENTOO_WINE_EBUILD_COMMON_PACKAGE_URI}" "${GENTOO_WINE_EBUILD_COMMON_PACKAGE}"
+	fetch_and_extract_tarball . "${GENTOO_WINE_EBUILD_PACKAGE_URI}" "${GENTOO_WINE_EBUILD_PACKAGE}.xz" "${GENTOO_WINE_EBUILD_PACKAGE}" "${WINE_EBUILD_COMMON}"      # fix: copy-out function added to fetch_and_extact_tarball.
 
 	# Fetch Wine-Staging Git Source (if required).
 	# Checkout desired Wine version in Wine-Staging Git tree (clean and update first!!)
@@ -2232,18 +2235,15 @@ function src_prepare()
 
 	# (1) Apply base (bundled) & working patches. Call 2 helper functions ...
 	local -a	array_patch_files=(
-		"${SOURCE_ROOT}/${WINE_EBUILD_COMMON}/patches/wine-1.8-gstreamer-1.0_"{01,02,03,04,05,06,07,08,09,10,11}".patch"
-		"${SOURCE_ROOT}/${WINE_EBUILD_COMMON}/patches/wine-1.9.13-gnutls-3.5-compat.patch"
-		"${SOURCE_ROOT}/${WINE_EBUILD_COMMON}/patches/wine-1.9.14-cups-2.2-cupsgetppd-build-fix.patch"
-		"${SOURCE_ROOT}/${WINE_EBUILD_COMMON}/patches/wine-1.9.9-sysmacros.patch"
-		"${SOURCE_ROOT}/${WINE_EBUILD_COMMON}/patches/wine-2.13-fix_build_with_newer_pcap.patch"
-		"${SOURCE_ROOT}/${WINE_EBUILD_COMMON}/patches/wine-2.18-freetype-2.8.1-drop-glyphs.patch"
-		"${SOURCE_ROOT}/${WINE_EBUILD_COMMON}/patches/wine-2.18-freetype-2.8.1-segfault.patch"
-		"${SOURCE_ROOT}/${WINE_EBUILD_COMMON}/patches/wine-2.7-osmesa-configure_support_recent_versions.patch"
+        "${SOURCE_ROOT}/${WINE_EBUILD_COMMON}/patches/wine-2.0-multislot-apploader.patch"
+        "${SOURCE_ROOT}/${WINE_EBUILD_COMMON}/patches/wine-4.7-multilib-portage.patch"
+        "${SOURCE_ROOT}/${WINE_EBUILD_COMMON}/patches/wine-5.0-winegcc.patch"
 	)
+
+    # UPDATE: Current gentoo ebuild has no bin patches, will leave functionality
+    #         in place for any futures.
 	# shellcheck disable=SC2034
 	local -a	array_binpatch_files=(
-		"${SOURCE_ROOT}/${WINE_EBUILD_COMMON}/patches/wine-2.18-freetype-2.8.1-implement_minimum_em_size_required_by_opentype_1.8.2.patch"
 	)
 
 	mkdir -p "${WORKING_PATCHES_DIRECTORY}"
@@ -3241,7 +3241,7 @@ function main()
 		printf "Read global configuration file: \"%s\"...\\n" "${TTYBLUE_BOLD}${SCRIPT_CONFIG}${TTYRESET}"
 	fi
 	# Global name constants
-	export 	GENTOO_WINE_EBUILD_COMMON_PACKAGE="gentoo-wine-ebuild-common"
+	export 	GENTOO_WINE_EBUILD_PACKAGE="gentoo-wine-patches"
 
 	# Global versioning defaults
 	parse_boolean_option "${WINE_STAGING}" "WINE_STAGING"
@@ -3261,16 +3261,16 @@ function main()
 	export	WINE_STAGING_PREFIX="v"
 	export	WINE_STAGING_SUFFIX="-unofficial"
 	export	WINE_PREFIX="wine-"
-	export	GENTOO_WINE_EBUILD_COMMON_PACKAGE_VERSION="20190428"
+	export	GENTOO_WINE_EBUILD_PACKAGE_VERSION="20191222"
 
 	# Global URI constants
 	export	WINE_STAGING_GIT_URI="https://github.com/wine-staging/wine-staging.git"
 	export	WINE_GIT_URI="git://source.winehq.org/git/wine.git"
 	export	WINE_ADDON_URI="http://dl.winehq.org/wine/"
-	export	GENTOO_WINE_EBUILD_COMMON_PACKAGE_URI="https://github.com/bobwya/${GENTOO_WINE_EBUILD_COMMON_PACKAGE}/archive/${GENTOO_WINE_EBUILD_COMMON_PACKAGE_VERSION}.tar.gz"
+	export	GENTOO_WINE_EBUILD_PACKAGE_URI="https://dev.gentoo.org/~sarnex/distfiles/wine/${GENTOO_WINE_EBUILD_PACKAGE}-${GENTOO_WINE_EBUILD_PACKAGE_VERSION}.tar.xz"
 	export	WINE_STAGING_BINPATCH_URI="https://raw.githubusercontent.com/wine-staging/wine-staging/master/patches/gitapply.sh"
 	export	WINE_STAGING_COMMIT_c48811407e3_URI="https://github.com/wine-staging/wine-staging/commit/c48811407e3c9cb2d6a448d6664f89bacd9cc36f.patch"
-	export	WINE_EBUILD_COMMON="${GENTOO_WINE_EBUILD_COMMON_PACKAGE}-${GENTOO_WINE_EBUILD_COMMON_PACKAGE_VERSION}"
+	export	WINE_EBUILD_COMMON="${GENTOO_WINE_EBUILD_PACKAGE}-${GENTOO_WINE_EBUILD_PACKAGE_VERSION}"
 
 	if ((WINE_STAGING)); then
 		set_wine_staging_git_tag 0

--- a/src/build_multilib_wine
+++ b/src/build_multilib_wine
@@ -1745,7 +1745,7 @@ function fetch_wine_addon()
 			;;
 		mono)
 			arch_array+=( "32" )
-			no_arch_suffix=1
+			no_arch_suffix=0
 			separator="-"
 			;;
 		*)

--- a/src/build_multilib_wine
+++ b/src/build_multilib_wine
@@ -1741,7 +1741,7 @@ function fetch_wine_addon()
 		gecko)
 			arch_array+=( "32" "64" )
 			no_arch_suffix=0
-			separator="_"
+			separator="-"
 			;;
 		mono)
 			arch_array+=( "32" )
@@ -2989,13 +2989,13 @@ function execute_commands()
 # WINE_VERSION="4.11"
 #
 # Git branch of Wine to build (WINE_STAGING=no).
-# WINE_BRANCH="refs/heads/master"
+# WINE_BRANCH="origin/master"
 #
 # Git commit (SHA-1 hash) of Wine to build (WINE_STAGING=no).
 # WINE_COMMIT=""
 #
 # Git branch of Wine-Staging to build (WINE_STAGING=yes).
-# WINE_STAGING_BRANCH="refs/heads/master"
+# WINE_STAGING_BRANCH="origin/master"
 #
 # Git commit (SHA-1 hash) of Wine-Staging to build (WINE_STAGING=yes).
 # WINE_STAGING_COMMIT=""

--- a/src/build_multilib_wine
+++ b/src/build_multilib_wine
@@ -513,7 +513,7 @@ function set_lsb_codename()
 function set_lsb_distribution_id()
 {
 	case "${LSB_CODENAME}" in
-		trusty|xenial|bionic|cosmic|disco|eoan)
+		trusty|xenial|bionic|cosmic|disco|eoan|bionic|focal)
 			LSB_DISTRIBUTION_ID="ubuntu"
 			;;
 		*)
@@ -1647,9 +1647,9 @@ get_optimum_repository_mirror()
 	if [[ "${LSB_DISTRIBUTION_ID}" == "debian" ]]; then
 		__test_file_relpath="dists/${LSB_CODENAME}/Release"
 		__repository_mirror_list="$(
-			netselect-apt "${LSB_CODENAME}" 2>/dev/null \
+			netselect-apt 2>/dev/null \
 				| gawk '{ if ($1~"^(https{0,1}|ftp):") { print $1 } }'
-		)"
+		)" # fix: net-select-apt new version / get mirrors always on any distro
 	else
 		__test_file_relpath="ubuntu/dists/${LSB_CODENAME}/Release"
 		__repository_mirror_list="$(wget -qO - "${__ubuntu_mirror_list}")"
@@ -1672,11 +1672,11 @@ get_optimum_repository_mirror()
 	if [[ -z "${__best_repository_mirror}" ]]; then
 		for __repository_mirror in "${__repository_mirror_array[@]}"; do
 			: $((++__i))
-			rm -f "${__temp_file}" &>/dev/null
-			if __download_time="$(
-				env time -f '%e' wget -t 1 -T 4 -qO "${__temp_file}" "${__repository_mirror}/${__test_file_relpath}" 2>&1 \
-					| gawk '{ if ($0 ~ "^[.[:digit:]]+$") { printf("%.0f\n", ($0*1000)) } else { exit 1 } }'
-			)"; then
+			rm -f "${__temp_file}" &>/dev/null	
+		    __basetime=$(date +%s%N) 
+            wget -t 1 -T 4 -qO "./tmp" "${__repository_mirror}${__test_file_relpath}" 2>&1 
+            if __download_time=$( (echo "scale=3;($(date +%s%N) - ${__basetime})/(1*10^9)" | bc) | gawk '{ if ($0 ~ "^[.[:digit:]]+$") { printf("%.0f\n", ($0*1000)) } else { exit 1 } }'
+			); then   # fix, more compatible timing method.
 				printf "[%02d] %s mirror: %s (%d ms)\\n" \
 						"$((__i))" "${LSB_DISTRIBUTION_ID^}" "${__repository_mirror}" "$((__download_time))"
 			else

--- a/src/build_multilib_wine
+++ b/src/build_multilib_wine
@@ -574,7 +574,10 @@ function check_package_dependencies()
 	fi
 
 	for executable in "${array_executables[@]}"; do
-		command -v "${executable}" &>/dev/null &&	continue
+		if [[ $(dpkg-query -W "${executable}" 2>&1) =~ .*no[[:space:]]packages[[:space:]]found.* ]] || \
+		   [ ! `command -v "${executable}" &>/dev/null` ]; then
+			continue
+		fi
 
 		case "${executable}" in
 			md5sum|mkfifo)

--- a/src/build_multilib_wine
+++ b/src/build_multilib_wine
@@ -2186,8 +2186,7 @@ function src_fetch()
 #
 #   (1) Generate a list of the current set of Gentoo patches.
 #       These patches are used to fix compilation issues, with earlier
-#       versions of Wine. There is a custom patch, to improve
-#       the appearance of the About tab in winecfg.
+#       versions of Wine. 
 #       Additionally there is a binary patch, used to fix
 #       font file issues, related to a previous freetype update.
 #       The sets of patches (binary and text) is filtered to remove any
@@ -2234,7 +2233,6 @@ function src_prepare()
 	# (1) Apply base (bundled) & working patches. Call 2 helper functions ...
 	local -a	array_patch_files=(
 		"${SOURCE_ROOT}/${WINE_EBUILD_COMMON}/patches/wine-1.8-gstreamer-1.0_"{01,02,03,04,05,06,07,08,09,10,11}".patch"
-		"${SOURCE_ROOT}/${WINE_EBUILD_COMMON}/patches/wine-1.8_winecfg_detailed_version.patch"
 		"${SOURCE_ROOT}/${WINE_EBUILD_COMMON}/patches/wine-1.9.13-gnutls-3.5-compat.patch"
 		"${SOURCE_ROOT}/${WINE_EBUILD_COMMON}/patches/wine-1.9.14-cups-2.2-cupsgetppd-build-fix.patch"
 		"${SOURCE_ROOT}/${WINE_EBUILD_COMMON}/patches/wine-1.9.9-sysmacros.patch"

--- a/src/sources.list
+++ b/src/sources.list
@@ -1,8 +1,0 @@
-# Debian packages for stable
-deb http://debian.mirror.globo.tech/debian/ stable main contrib
-# Uncomment the deb-src line if you want 'apt-get source'
-# to work with most packages.
-# deb-src http://debian.mirror.globo.tech/debian/ stable main contrib
-
-# Security updates for stable
-deb http://security.debian.org/ stable/updates main contrib

--- a/src/sources.list
+++ b/src/sources.list
@@ -1,0 +1,8 @@
+# Debian packages for stable
+deb http://debian.mirror.globo.tech/debian/ stable main contrib
+# Uncomment the deb-src line if you want 'apt-get source'
+# to work with most packages.
+# deb-src http://debian.mirror.globo.tech/debian/ stable main contrib
+
+# Security updates for stable
+deb http://security.debian.org/ stable/updates main contrib


### PR DESCRIPTION
# Bugfix PR

This Merge Pull Request gets the script working again on modern systems after many updates have changed the way that some things work.

## Bugfixes for ``set_lsb_distribution_id``

- In ``set_lsb_distribution_id``, verbs for bionic and focal (new releases of Ubuntu out since the script's last update)

## Bugfixes for ``check_package_dependencies``

- In ``check_package_dependencies``, a more reliable method of checking whether or not a package exists on the host system without root access.  ``command -V debootstrap`` and several others now fail as a recent update to debootstrap's permission requirements require that this command be run as root.  This new method tries the old method, in combination with the new one, and does not have to be run as root.  Package installs are checked directly with ``dpkg-query -W`` first, with a safety-net fall-through to ``command -V`` which is more reliable and provides a layer of backwards compatibility.

## Bugfixes for ``get_optimum_repository_mirror``

- In ``get_optimum_repository_mirror`` , a trailing forward slash ``/`` in URI output given by ``netselect-apt`` was breaking mirror Release file downloads.  That was fixed.
- In ``get_optimum_repository_mirror``, ``netselect-apt`` was updated on debian systems recently, requiring some thinking and a bug fix.   As the verbs for stable/unstable/testing and release version are pulled through the Release file, passing it as an argument here was both redundant and non-working after the ``netselect-apt`` update.  It now fetches a proper mirror list.
- In ``get_optimum_repository_mirror`` , the timing method used did not work on all systems.  It was updated to use the ``date`` command which further works in Debian and on Ubuntu host systems properly.  ``env time -f`` is deprecated on these host systems and produces error ``Unrecognized command -f`` on the pipe on Debian and Ubuntu host systems.  This compatibility update to the timing method gets the mirror timing functionality working on most modern host Debian/Ubuntu systems as well as many other distributions.

## Bugfixes for ``execute_commands``

- In  ``execute_commands``, WineHQ repository branch naming schema has changed.  The default configuration produces an error prompting for a correction to origin/master .  Now the default working value is suggested properly to the user to mitigate any confusion.  If the user uncomments this line, they will receive a working configuration that will not produce this error. 

## Bugfixes for ``fetch_wine_addon``
- In ``fetch_wine_addon``, wine-gecko instead of wine_gecko.  WineHQ developers corrected this inconsistency in package naming since this script was written.  This fixes the gecko 404 error.

- In ``fetch_wine_addon``, wine-mono-5.0.0-x86 instead of wine-mono-5.0.0.  WineHQ developers renamed wine-mono package to always have x86 suffix.  This fixes the mono 404 error.

## Test results
```
make[1]: Leaving directory '/home/heavypaws/.wine/build/wine32/programs/winetest'
Wine build complete.
~/Downloads/build-multilib-wine/src

build_multilib_wine: Build phase: src-compile; has completed successfully,  for Wine 5.0 ...
```

## PR Notes

This PR is undergoing extensive testing under the following host environments.  Any further commits to it are bugfix / adjustments for the following distribution host target configurations.

- Ubuntu 16.04.6 LTS / ``xenial stable contrib nonfree universe multiverse``
- Ubuntu 18.04.4 LTS / ``boinic stable contrib nonfree universe multiverse``
- Ubuntu 20.04 LTS / ``focal stable contrib nonfree universe multiverse``
- Debian 9 / ``stretch main contrib nonfree``
- Debian 10 / ``buster main contrib nonfree``

## About libfaudio0 (seen in "FIXME:" about libfaudio.

Conditional code is required to build newer versions of wine with libfaudio along with an faudio patch and a ``Makefile`` patch so that the 64 bit chroot ``make`` can see libfaudio installation.

libfaudio can be included by the following build script: in your custom build  https://github.com/Kron4ek/FAudio-Builds .  Mingw is required to build PE dependencies, including faudio support.

The script complains about missing mingw dependency nowadays.  As the build is successful without mingw, I have not considered this a bug, nor the missing faudio, which is outside of the scope of this bugfix PR.

I do however acknoweldge this, and can offer up an additional PR for faudio support by building it in the 64 bit chroot integrated into the build script should this PR / fixup make it to the main repository, otherwise I will be updating my own fork to include support for faudio.